### PR TITLE
beautify-form

### DIFF
--- a/app/controllers/api/v1/trainings_controller.rb
+++ b/app/controllers/api/v1/trainings_controller.rb
@@ -56,7 +56,7 @@ end
   private
 
    def training_params
-    params.require(:training).permit(:title, :description, :price_per_hour, :location, :min_start_time, :max_end_time, tag_list: [])
+    params.require(:training).permit(:image, :user_id, :title, :description, :price_per_hour, :location, tag_list: [])
   end
 
   def render_error


### PR DESCRIPTION
for the backend, removed @training.user = @user to fix the frontend bug training form to redirect to show page.


evening changes 6:36 added permit parameters image and user_id and removed the min_start time and max end time.
def training_params
    params.require(:training).permit(:image, :user_id, :title, :description, :price_per_hour, :location, tag_list: [])